### PR TITLE
Binutils 2.25 and or1k with upstream binutils for rtems 4.11

### DIFF
--- a/rtems/config/4.11/rtems-or1k.bset
+++ b/rtems/config/4.11/rtems-or1k.bset
@@ -15,10 +15,6 @@
 # or1k specific patches
 #
 
-#binutils
-%patch add binutils -p1 https://raw.githubusercontent.com/heshamelmatary/or1k-rtems/master/patches/binutils-2.24-or1k-rtems.diff
-%hash  md5 binutils-2.24-or1k-rtems.diff 6a1d5ae6e37f6eed421b357a63a612db
-
 #gcc
 %patch add gcc -p1 https://raw.githubusercontent.com/heshamelmatary/or1k-rtems/master/patches/gcc-4.8.3-or1k-rtems-29072014.diff
 %hash  md5 gcc-4.8.3-or1k-rtems-29072014.diff df2555b2dd4de2d78366fabd705f36ac
@@ -41,7 +37,7 @@
 #
 4.11/rtems-autotools
 devel/expat-2.1.0-1
-tools/rtems-binutils-2.24-1
+tools/rtems-binutils-2.25-1
 tools/rtems-gcc-4.8.3-newlib-git-1
 tools/rtems-tools-4.11-1
 tools/rtems-gdb-7.7-1

--- a/rtems/config/tools/rtems-binutils-2.25-1.cfg
+++ b/rtems/config/tools/rtems-binutils-2.25-1.cfg
@@ -1,0 +1,22 @@
+#
+# Binutils 2.25.
+#
+
+%include %{_configdir}/checks.cfg
+%include %{_configdir}/base.cfg
+
+%define binutils_version 2.25
+
+%hash md5 binutils-%{binutils_version}.tar.bz2 d9f3303f802a5b6b0bb73a335ab89d66
+
+#
+# Enable deterministic archives by default. This will be the default
+# there all tools using this binutils will create deterministic
+# archives.
+#
+%define with_deterministic_archives 1
+
+#
+# The binutils build instructions. We use 2.xx Release 1.
+#
+%include %{_configdir}/binutils-2-1.cfg


### PR DESCRIPTION
Hi,

I am currently preparing a few releases of or1k cross compilers and thereby found that this one may be updated to bintuils 2.25, where or1k is upstreamed now.

Cheers,
Stefan