### PR TITLE
Builder instead of Bulder

### DIFF
--- a/source-builder/sb-set-builder
+++ b/source-builder/sb-set-builder
@@ -25,5 +25,5 @@ try:
     import setbuilder
     setbuilder.run()
 except ImportError:
-    print >> sys.stderr, "Incorrect Set Bulder installation"
+    print >> sys.stderr, "Incorrect Set Builder installation"
     sys.exit(1)


### PR DESCRIPTION
Typo mistake in documentation .I would like to edit "Builder" instead of "Bulder"