### PR TITLE
Various bugfixes for building rtems 4.9,4.10,4.11 and 4.12

### DIFF
--- a/rtems/config/tools/rtems-binutils-2.20.1-1.cfg
+++ b/rtems/config/tools/rtems-binutils-2.20.1-1.cfg
@@ -10,6 +10,7 @@
 %hash md5 binutils-%{binutils_version}.tar.bz2 2b9dc8f2b7dbd5ec5992c6e29de0b764
 
 %patch add binutils %{rtems_binutils_patches}/binutils-2.20.1-rtems4.10-20100826.diff
+%patch add binutils file://%{_sbdir}/patches/binutils-2.20.1.diff
 %hash md5 binutils-2.20.1-rtems4.10-20100826.diff 733899876e0b32ce0700666b29662d91
 %ifos win32 mingw ming32 cygwin
  %patch add binutils %{rtems_binutils_patches}/cygwin/binutils-2.20.1-cygwin-w64-20130324.diff

--- a/rtems/config/tools/rtems-gcc-4.3.2-newlib-1.16.0-1.cfg
+++ b/rtems/config/tools/rtems-gcc-4.3.2-newlib-1.16.0-1.cfg
@@ -20,6 +20,7 @@
 #
 %source set gcc ftp://ftp.gnu.org/pub/gnu/gcc/gcc-%{gcc_version}/gcc-core-%{gcc_version}.tar.bz2
 %patch  add gcc %{rtems_gcc_patches}/gcc-core-4.3.2-rtems4.9-20090825.diff
+%patch  add gcc ftp://%{_sbdir}/patches/gcc-4.3.2.diff
 %source add gcc ftp://ftp.gnu.org/pub/gnu/gcc/gcc-%{gcc_version}/gcc-g++-%{gcc_version}.tar.bz2
 %patch  add newlib %{rtems_newlib_patches}/newlib-1.16.0-rtems4.9-20090324.diff
 

--- a/rtems/config/tools/rtems-gcc-4.3.2-newlib-1.16.0-1.cfg
+++ b/rtems/config/tools/rtems-gcc-4.3.2-newlib-1.16.0-1.cfg
@@ -21,7 +21,7 @@
 %source set gcc ftp://ftp.gnu.org/pub/gnu/gcc/gcc-%{gcc_version}/gcc-core-%{gcc_version}.tar.bz2
 %patch  add gcc %{rtems_gcc_patches}/gcc-core-4.3.2-rtems4.9-20090825.diff
 %source add gcc ftp://ftp.gnu.org/pub/gnu/gcc/gcc-%{gcc_version}/gcc-g++-%{gcc_version}.tar.bz2
-%patch  add gcc %{rtems_newlib_patches}/newlib-1.16.0-rtems4.9-20090324.diff
+%patch  add newlib %{rtems_newlib_patches}/newlib-1.16.0-rtems4.9-20090324.diff
 
 #
 # The gcc/newlib build instructions. We use 4.7 Release 1.

--- a/rtems/config/tools/rtems-gcc-4.4.7-newlib-1.18.0-1.cfg
+++ b/rtems/config/tools/rtems-gcc-4.4.7-newlib-1.18.0-1.cfg
@@ -39,6 +39,7 @@
 #
 %patch add gcc %{rtems_gcc_patches}/gcc-core-4.4.7-rtems4.10-20120314.diff
 %hash md5 gcc-core-4.4.7-rtems4.10-20120314.diff 084c9085c255b1f6a9204e239dde0579
+%patch add gcc file://%{_sbdir}/patches/gcc-4.4.7.diff
 %if %{enable_cxx}
  %patch add gcc %{rtems_gcc_patches}/gcc-g++-4.4.7-rtems4.10-20120314.diff
  %hash md5 gcc-g++-4.4.7-rtems4.10-20120314.diff e187db20f6d98048368f9ef86f9126dc

--- a/rtems/config/tools/rtems-gdb-7.3.1-1.cfg
+++ b/rtems/config/tools/rtems-gdb-7.3.1-1.cfg
@@ -10,6 +10,7 @@
 %hash md5 gdb-%{gdb_version}.tar.bz2 b89a5fac359c618dda97b88645ceab47
 
 %patch add gdb %{rtems_gdb_patches}/gdb-7.3.1-rtems4.10-20120918.diff
+%patch add gdb file://%{_sbdir}/patches/gdb-7.3.1.diff
 %hash md5 gdb-7.3.1-rtems4.10-20120918.diff 81607fc7366fe2ee0a2c8f991929acdc
 
 #

--- a/rtems/config/tools/rtems-kernel-4-1.cfg
+++ b/rtems/config/tools/rtems-kernel-4-1.cfg
@@ -16,7 +16,9 @@ BuildRoot: %{_tmppath}/%{name}-root-%(%{__id_u} -n)
 #
 # Source
 #
-%source set rtems http://ftp.rtems.org/pub/rtems/%{rtems_kernel_version}/rtems-%{rtems_kernel_version}.tar.bz2
+
+%define rtems_major_kernel_version %(echo %{rtems_kernel_version} | sed -e 's/\.[^\.]\+$//')
+%source set rtems http://ftp.rtems.org/pub/rtems/releases/%{rtems_major_kernel_version}/%{rtems_kernel_version}/rtems-%{rtems_kernel_version}.tar.bz2
 
 #
 # If C++ defined for the tool set use it to control RTEMS's setting..

--- a/source-builder/patches/binutils-2.20.1.diff
+++ b/source-builder/patches/binutils-2.20.1.diff
@@ -1,0 +1,21 @@
+diff -Naur binutils-2.20.1-orig/bfd/doc/bfd.texinfo binutils-2.20.1/bfd/doc/bfd.texinfo
+--- binutils-2.20.1-orig/bfd/doc/bfd.texinfo	2015-11-16 16:25:33.558111584 +0100
++++ binutils-2.20.1/bfd/doc/bfd.texinfo	2015-11-16 16:25:45.101954752 +0100
+@@ -323,7 +323,7 @@
+ @printindex cp
+ 
+ @tex
+-% I think something like @colophon should be in texinfo.  In the
++% I think something like @@colophon should be in texinfo.  In the
+ % meantime:
+ \long\def\colophon{\hbox to0pt{}\vfill
+ \centerline{The body of this manual is set in}
+@@ -334,7 +334,7 @@
+ \centerline{{\sl\fontname\tensl\/}}
+ \centerline{are used for emphasis.}\vfill}
+ \page\colophon
+-% Blame: doc@cygnus.com, 28mar91.
++% Blame: doc@@cygnus.com, 28mar91.
+ @end tex
+ 
+ @bye

--- a/source-builder/patches/gcc-4.3.2.diff
+++ b/source-builder/patches/gcc-4.3.2.diff
@@ -1,0 +1,91 @@
+diff -Naur gcc-4.3.2-orig/gcc/doc/c-tree.texi gcc-4.3.2/gcc/doc/c-tree.texi
+--- gcc-4.3.2-orig/gcc/doc/c-tree.texi	2008-02-17 19:52:04.000000000 +0100
++++ gcc-4.3.2/gcc/doc/c-tree.texi	2015-11-19 15:57:28.246547226 +0100
+@@ -2325,13 +2325,13 @@
+ not matter.  The type of the operands and that of the result are
+ always of @code{BOOLEAN_TYPE} or @code{INTEGER_TYPE}.
+ 
+-@itemx POINTER_PLUS_EXPR
++@item POINTER_PLUS_EXPR
+ This node represents pointer arithmetic.  The first operand is always
+ a pointer/reference type.  The second operand is always an unsigned
+ integer type compatible with sizetype.  This is the only binary
+ arithmetic operand that can operate on pointer types.
+ 
+-@itemx PLUS_EXPR
++@item PLUS_EXPR
+ @itemx MINUS_EXPR
+ @itemx MULT_EXPR
+ These nodes represent various binary arithmetic operations.
+diff -Naur gcc-4.3.2-orig/gcc/doc/cppopts.texi gcc-4.3.2/gcc/doc/cppopts.texi
+--- gcc-4.3.2-orig/gcc/doc/cppopts.texi	2007-07-30 20:29:20.000000000 +0200
++++ gcc-4.3.2/gcc/doc/cppopts.texi	2015-11-19 15:57:28.246547226 +0100
+@@ -754,7 +754,7 @@
+ Enable special code to work around file systems which only permit very
+ short file names, such as MS-DOS@.
+ 
+-@itemx --help
++@item --help
+ @itemx --target-help
+ @opindex help
+ @opindex target-help
+diff -Naur gcc-4.3.2-orig/gcc/doc/extend.texi gcc-4.3.2/gcc/doc/extend.texi
+--- gcc-4.3.2-orig/gcc/doc/extend.texi	2008-07-15 17:52:35.000000000 +0200
++++ gcc-4.3.2/gcc/doc/extend.texi	2015-11-19 16:00:11.664369617 +0100
+@@ -2861,6 +2861,8 @@
+ The possible values of @var{visibility_type} correspond to the
+ visibility settings in the ELF gABI.
+ 
++@end table
++
+ @table @dfn
+ @c keep this list of visibilities in alphabetical order.
+ 
+@@ -2901,8 +2903,6 @@
+ definition in that module.  That is, the declared entity cannot be
+ overridden by another module.
+ 
+-@end table
+-
+ All visibilities are supported on many, but not all, ELF targets
+ (supported when the assembler supports the @samp{.visibility}
+ pseudo-op).  Default visibility is supported everywhere.  Hidden
+@@ -4231,7 +4231,7 @@
+ Otherwise the two shared objects will be unable to use the same
+ typeinfo node and exception handling will break.
+ 
+-@subsection ARM Type Attributes
++@item ARM Type Attributes
+ 
+ On those ARM targets that support @code{dllimport} (such as Symbian
+ OS), you can use the @code{notshared} attribute to indicate that the
+@@ -4255,7 +4255,7 @@
+ most Symbian OS code uses @code{__declspec}.)
+ 
+ @anchor{i386 Type Attributes}
+-@subsection i386 Type Attributes
++@item i386 Type Attributes
+ 
+ Two attributes are currently defined for i386 configurations:
+ @code{ms_struct} and @code{gcc_struct}
+diff -Naur gcc-4.3.2-orig/gcc/doc/invoke.texi gcc-4.3.2/gcc/doc/invoke.texi
+--- gcc-4.3.2-orig/gcc/doc/invoke.texi	2008-06-25 03:37:53.000000000 +0200
++++ gcc-4.3.2/gcc/doc/invoke.texi	2015-11-19 15:57:28.254547117 +0100
+@@ -957,7 +957,7 @@
+ generic, or subprogram renaming declaration).  Such files are also
+ called @dfn{specs}.
+ 
+-@itemx @var{file}.adb
++@item @var{file}.adb
+ Ada source code file containing a library unit body (a subprogram or
+ package body).  Such files are also called @dfn{bodies}.
+ 
+@@ -8569,7 +8569,7 @@
+ @samp{cortex-a8}, @samp{cortex-r4}, @samp{cortex-m3},
+ @samp{xscale}, @samp{iwmmxt}, @samp{ep9312}.
+ 
+-@itemx -mtune=@var{name}
++@item -mtune=@var{name}
+ @opindex mtune
+ This option is very similar to the @option{-mcpu=} option, except that
+ instead of specifying the actual target processor type, and hence

--- a/source-builder/patches/gcc-4.4.7.diff
+++ b/source-builder/patches/gcc-4.4.7.diff
@@ -1,0 +1,86 @@
+--- gcc-4.4.7-orig/gcc/doc/c-tree.texi	2009-02-20 16:20:38.000000000 +0100
++++ gcc-4.4.7/gcc/doc/c-tree.texi	2015-11-17 09:43:59.054448894 +0100
+@@ -2338,13 +2338,13 @@
+ not matter.  The type of the operands and that of the result are
+ always of @code{BOOLEAN_TYPE} or @code{INTEGER_TYPE}.
+ 
+-@itemx POINTER_PLUS_EXPR
++@item  POINTER_PLUS_EXPR
+ This node represents pointer arithmetic.  The first operand is always
+ a pointer/reference type.  The second operand is always an unsigned
+ integer type compatible with sizetype.  This is the only binary
+ arithmetic operand that can operate on pointer types.
+ 
+-@itemx PLUS_EXPR
++@item  PLUS_EXPR
+ @itemx MINUS_EXPR
+ @itemx MULT_EXPR
+ These nodes represent various binary arithmetic operations.
+--- gcc-4.4.7-orig/gcc/doc/cppopts.texi	2008-06-15 11:42:13.000000000 +0200
++++ gcc-4.4.7/gcc/doc/cppopts.texi	2015-11-17 09:40:09.377639641 +0100
+@@ -758,7 +758,7 @@
+ Enable special code to work around file systems which only permit very
+ short file names, such as MS-DOS@.
+ 
+-@itemx --help
++@item --help
+ @itemx --target-help
+ @opindex help
+ @opindex target-help
+--- gcc-4.4.7-orig/gcc/doc/invoke.texi	2015-11-16 16:56:48.140502438 +0100
++++ gcc-4.4.7/gcc/doc/invoke.texi	2015-11-17 09:55:03.217222123 +0100
+@@ -4649,11 +4649,11 @@
+ @option{-fdump-rtl-ce3} enable dumping after the three
+ if conversion passes. 
+ 
+-@itemx -fdump-rtl-cprop_hardreg
++@item -fdump-rtl-cprop_hardreg
+ @opindex fdump-rtl-cprop_hardreg
+ Dump after hard register copy propagation.
+ 
+-@itemx -fdump-rtl-csa
++@item -fdump-rtl-csa
+ @opindex fdump-rtl-csa
+ Dump after combining stack adjustments.
+ 
+@@ -4664,11 +4664,11 @@
+ @option{-fdump-rtl-cse1} and @option{-fdump-rtl-cse2} enable dumping after
+ the two common sub-expression elimination passes.
+ 
+-@itemx -fdump-rtl-dce
++@item -fdump-rtl-dce
+ @opindex fdump-rtl-dce
+ Dump after the standalone dead code elimination passes.
+ 
+-@itemx -fdump-rtl-dbr
++@item -fdump-rtl-dbr
+ @opindex fdump-rtl-dbr
+ Dump after delayed branch scheduling.
+ 
+@@ -4713,7 +4713,7 @@
+ @opindex fdump-rtl-initvals
+ Dump after the computation of the initial value sets.
+ 
+-@itemx -fdump-rtl-into_cfglayout
++@item -fdump-rtl-into_cfglayout
+ @opindex fdump-rtl-into_cfglayout
+ Dump after converting to cfglayout mode.
+ 
+@@ -4743,7 +4743,7 @@
+ @opindex fdump-rtl-rnreg
+ Dump after register renumbering.
+ 
+-@itemx -fdump-rtl-outof_cfglayout
++@item -fdump-rtl-outof_cfglayout
+ @opindex fdump-rtl-outof_cfglayout
+ Dump after converting from cfglayout mode.
+ 
+@@ -4755,7 +4755,7 @@
+ @opindex fdump-rtl-postreload
+ Dump after post-reload optimizations.
+ 
+-@itemx -fdump-rtl-pro_and_epilogue
++@item -fdump-rtl-pro_and_epilogue
+ @opindex fdump-rtl-pro_and_epilogue
+ Dump after generating the function pro and epilogues.
+ 

--- a/source-builder/patches/gdb-7.3.1.diff
+++ b/source-builder/patches/gdb-7.3.1.diff
@@ -1,0 +1,49 @@
+--- gdb-7.3.1-orig/gdb/doc/gdb.texinfo	2011-09-04 19:10:37.000000000 +0200
++++ gdb-7.3.1/gdb/doc/gdb.texinfo	2015-11-17 10:21:29.671415980 +0100
+@@ -4792,7 +4792,7 @@
+ 
+ 
+ @kindex advance @var{location}
+-@itemx advance @var{location}
++@item advance @var{location}
+ Continue running the program up to the given @var{location}.  An argument is
+ required, which should be of one of the forms described in
+ @ref{Specify Location}.
+@@ -5582,7 +5582,7 @@
+ @kindex set exec-direction
+ @item set exec-direction
+ Set the direction of target execution.
+-@itemx set exec-direction reverse
++@item set exec-direction reverse
+ @cindex execute forward or backward in time
+ @value{GDBN} will perform all execution commands in reverse, until the
+ exec-direction mode is changed to ``forward''.  Affected commands include
+@@ -36954,7 +36954,7 @@
+ @printindex cp
+ 
+ @tex
+-% I think something like @colophon should be in texinfo.  In the
++% I think something like @@colophon should be in texinfo.  In the
+ % meantime:
+ \long\def\colophon{\hbox to0pt{}\vfill
+ \centerline{The body of this manual is set in}
+@@ -36966,7 +36966,7 @@
+ \centerline{{\sl\fontname\tensl\/}}
+ \centerline{are used for emphasis.}\vfill}
+ \page\colophon
+-% Blame: doc@cygnus.com, 1991.
++% Blame: doc@@cygnus.com, 1991.
+ @end tex
+ 
+ @bye
+--- gdb-7.3.1-orig/gdb/doc/gdbint.texinfo	2011-02-04 20:10:12.000000000 +0100
++++ gdb-7.3.1/gdb/doc/gdbint.texinfo	2015-11-17 11:38:55.061697037 +0100
+@@ -35,7 +35,7 @@
+ 
+ @titlepage
+ @title @value{GDBN} Internals
+-@subtitle{A guide to the internals of the GNU debugger}
++@subtitle A guide to the internals of the GNU debugger
+ @author John Gilmore
+ @author Cygnus Solutions
+ @author Second Edition:

--- a/source-builder/sb/download.py
+++ b/source-builder/sb/download.py
@@ -264,7 +264,8 @@ def _file_parser(source, pathkey, config, opts):
     #
     # Get the paths sorted.
     #
-    source['file'] = source['url'][6:]
+    source['file'] = source['url'][7:]
+    return True
 
 parsers = { 'http': _http_parser,
             'ftp':  _http_parser,
@@ -511,7 +512,8 @@ def _cvs_downloader(url, local, config, opts):
 
 def _file_downloader(url, local, config, opts):
     try:
-        path.copy(url[6:], local)
+        if url[7:]!=local:
+            path.copy(url[7:], local)
     except:
         return False
     return True


### PR DESCRIPTION
Hello, I have used the rtems-source-builder to build rtems 4.9,4.10,4.11 and 4.12 on our development host that runs with debian 7. I encountered some problems and have fixed them with a few patches. Maybe you can integrate these in the main repository.